### PR TITLE
Update listed kup releases

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -22,3 +22,5 @@ jobs:
           poetry --version
       - name: 'Formatting and Type Checking'
         run: make
+      - name: 'Kup list works'
+        run: poetry run kup list

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -16,6 +16,18 @@ jobs:
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3
+      - name: 'Install Nix/Cachix'
+        uses: cachix/install-nix-action@v18
+        with:
+          # Keep nix at <=2.7 https://github.com/NixOS/nix/issues/6572
+          install_url: https://releases.nixos.org/nix/nix-2.7.0/install
+          extra_nix_config: |
+            substituters = http://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      - uses: cachix/cachix-action@v10
+        with:
+          name: runtimeverification
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: 'Install Poetry'
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -80,6 +80,7 @@ available_packages: Dict[str, AvailablePackage] = {
     'k': AvailablePackage('k', f'packages.{SYSTEM}.k'),
     'kevm': AvailablePackage('evm-semantics', f'packages.{SYSTEM}.kevm'),
     'kore-exec': AvailablePackage('haskell-backend', f'packages.{SYSTEM}.kore:exe:kore-exec'),
+    'pyk': AvailablePackage('pyk', f'packages.{SYSTEM}.pyk'),
 }
 
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -76,7 +76,7 @@ class AvailablePackage:
 
 
 available_packages: Dict[str, AvailablePackage] = {
-    'kup': AvailablePackage('k', f'packages.{SYSTEM}.kup'),
+    'kup': AvailablePackage('kup', f'packages.{SYSTEM}.kup'),
     'k': AvailablePackage('k', f'packages.{SYSTEM}.k'),
     'kevm': AvailablePackage('evm-semantics', f'packages.{SYSTEM}.kevm'),
     'kore-exec': AvailablePackage('haskell-backend', f'packages.{SYSTEM}.kore:exe:kore-exec'),


### PR DESCRIPTION
This PR does several things:

- Updates the URL for `kup` utility installation to point at this repo.
- Adds the `pyk` executable to `kup` installation utility.
- Tests that poetry-built `kup` works on CI.