### PR TITLE
Add a `--override` flag for install/update/shell

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9' 
       - name: 'Install Poetry'
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/poetry.lock
+++ b/poetry.lock
@@ -10,11 +10,11 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "autoflake"
-version = "1.7.6"
+version = "1.7.7"
 description = "Removes unused imports and unused variables"
 category = "dev"
 optional = false
@@ -63,7 +63,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -78,11 +78,11 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
 name = "flake8"
@@ -99,18 +99,18 @@ pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
 name = "flake8-bugbear"
-version = "22.9.23"
+version = "22.10.25"
 description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=19.2.0"
 flake8 = ">=3.0.0"
 
 [package.extras]
-dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
+dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "tox"]
 
 [[package]]
 name = "flake8-comprehensions"
@@ -152,9 +152,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements_deprecated_finder = ["pip-api", "pipreqs"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "mccabe"
@@ -222,6 +222,14 @@ docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
+name = "pptree"
+version = "3.1"
+description = "Pretty print trees"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.9.1"
 description = "Python style guide checker"
@@ -253,7 +261,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "terminaltables"
@@ -314,7 +322,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "4322757715990031bf3ea858d0c9efbad56ffb80d76e16912644d6a837d1d6bd"
+content-hash = "8dc5cd56bf26a921bfb2ac2c0939a51bed4c2afe35a42205a73c3728ced6af87"
 
 [metadata.files]
 attrs = [
@@ -322,8 +330,8 @@ attrs = [
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 autoflake = [
-    {file = "autoflake-1.7.6-py3-none-any.whl", hash = "sha256:9fa63cb814c1dfc02103a361b449c024226348c2130b6839cd94278c309c4a65"},
-    {file = "autoflake-1.7.6.tar.gz", hash = "sha256:f2a8e107ba6c02a25e0acf2beebab247792998132e6b1f24efa7b0b7faa30cb6"},
+    {file = "autoflake-1.7.7-py3-none-any.whl", hash = "sha256:a9b43d08f8e455824e4f7b3f078399f59ba538ba53872f466c09e55c827773ef"},
+    {file = "autoflake-1.7.7.tar.gz", hash = "sha256:c8e4fc41aa3eae0f5c94b939e3a3d50923d7a9306786a6cbf4866a077b8f6832"},
 ]
 black = [
     {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
@@ -361,16 +369,16 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
 ]
 flake8-bugbear = [
-    {file = "flake8-bugbear-22.9.23.tar.gz", hash = "sha256:17b9623325e6e0dcdcc80ed9e4aa811287fcc81d7e03313b8736ea5733759937"},
-    {file = "flake8_bugbear-22.9.23-py3-none-any.whl", hash = "sha256:cd2779b2b7ada212d7a322814a1e5651f1868ab0d3f24cc9da66169ab8fda474"},
+    {file = "flake8-bugbear-22.10.25.tar.gz", hash = "sha256:89e51284eb929fbb7f23fbd428491e7427f7cdc8b45a77248daffe86a039d696"},
+    {file = "flake8_bugbear-22.10.25-py3-none-any.whl", hash = "sha256:584631b608dc0d7d3f9201046d5840a45502da4732d5e8df6c7ac1694a91cb9e"},
 ]
 flake8-comprehensions = [
     {file = "flake8-comprehensions-3.10.0.tar.gz", hash = "sha256:181158f7e7aa26a63a0a38e6017cef28c6adee71278ce56ce11f6ec9c4905058"},
@@ -432,6 +440,9 @@ pep8-naming = [
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pptree = [
+    {file = "pptree-3.1.tar.gz", hash = "sha256:4dd0ba2f58000cbd29d68a5b64bac29bcb5a663642f79404877c0059668a69f6"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python = "^3.8"
 terminaltables = "^3.1.10"
 requests = "^2.28.1"
 types-requests = "^2.28.11"
+pptree = "^3.1"
 
 [tool.poetry.group.dev.dependencies]
 autoflake = "*"
@@ -48,3 +49,4 @@ skip-string-normalization = true
 
 [tool.mypy]
 disallow_untyped_defs = true
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 kup = "kup.__main__:main"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 terminaltables = "^3.1.10"
 requests = "^2.28.1"
 types-requests = "^2.28.11"

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -348,7 +348,7 @@ def mk_override_args(
             if override_input:
                 print(
                     f"⚠️ \033[93mThe input '\033[94m{input}\033[93m' you are trying to override follows '\033[94m{override_input}\033[93m'.\n",
-                    f"You may want to call this command with '\033[94m--override {override_input}\033[93m' instead.\033[0m"
+                    f"You may want to call this command with '\033[94m--override {override_input}\033[93m' instead.\033[0m",
                 )
             else:
                 print(

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -3,10 +3,11 @@ import os
 import subprocess
 import sys
 import textwrap
-from argparse import ArgumentParser
-from typing import Dict, List, Optional, Union
+from argparse import ArgumentParser, BooleanOptionalAction
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
+from pptree import Node, print_tree
 from terminaltables import SingleTable  # type: ignore
 
 INSTALLED = '🟢 \033[92minstalled\033[0m'
@@ -50,7 +51,6 @@ SYSTEM = (
     .replace('"', '')
 )
 
-
 # nix tends to fail on macs with a segfault so we add `GC_DONT_GC=1` if on macOS (i.e. darwin)
 # The `GC_DONT_GC` simply disables the garbage collector used during evaluation of a nix
 # expression. This may cause the process to run out of memory, but hasn't been observed for our
@@ -88,7 +88,13 @@ class ConcretePackage:
     __slots__ = ['repo', 'package', 'status', 'version', 'immutable', 'index']
 
     def __init__(
-        self, repo: str, package: str, status: str, version: str = '-', immutable: bool = True, index: int = -1
+        self,
+        repo: str,
+        package: str,
+        status: str,
+        version: str = '-',
+        immutable: bool = True,
+        index: int = -1,
     ):
         self.repo = repo
         self.package = package
@@ -110,6 +116,102 @@ def check_package_version(p: AvailablePackage, current_url: str) -> str:
         return INSTALLED
     else:
         return UPDATE
+
+
+# walk all the inputs and their inputs and collect only the ones pointing to runtimeverification repos
+def process_input(nodes: dict, key: str, override: bool = False) -> dict:
+    if (
+        'original' in nodes[key]
+        and 'owner' in nodes[key]['original']
+        and nodes[key]['original']['owner'] == 'runtimeverification'
+    ):
+        repo = nodes[key]['original']['repo']
+        rev = nodes[key]['locked']['rev']
+        if 'inputs' not in nodes[key]:
+            return {key: {'repo': repo, 'rev': rev}}
+        else:
+            inputs: dict = {}
+            for key_input, path in nodes[key]['inputs'].items():
+                if type(path) != list:
+                    inputs = inputs | process_input(nodes, path)
+                else:
+                    last = path[-1]
+                    if (
+                        'original' in nodes[last]
+                        and 'owner' in nodes[last]['original']
+                        and nodes[last]['original']['owner'] == 'runtimeverification'
+                    ):
+                        inputs[key_input] = {'follows': path}
+
+            return {key: {'repo': repo, 'rev': rev, 'inputs': inputs}}
+
+    elif override:
+        if 'inputs' not in nodes[key]:
+            return {}
+        else:
+            inputs = {}
+            for key_input, path in nodes[key]['inputs'].items():
+                if type(path) != list:
+                    inputs = inputs | process_input(nodes, path)
+                else:
+                    last = path[-1]
+                    if (
+                        'original' in nodes[last]
+                        and 'owner' in nodes[last]['original']
+                        and nodes[last]['original']['owner'] == 'runtimeverification'
+                    ):
+                        inputs[key_input] = {'follows': path}
+            return {key: {'inputs': inputs}}
+    else:
+        return {}
+
+
+def get_package_inputs(name: str, package: Union[AvailablePackage, ConcretePackage]) -> dict:
+    try:
+        result = nix(['flake', 'metadata', f'github:runtimeverification/{package.repo}', '--json'])
+    except Exception:
+        return {}
+    meta = json.loads(result)
+    root = meta['locks']['root']
+
+    return {name: process_input(meta['locks']['nodes'], root, True)[root]}
+
+
+def print_package_tree(inputs: dict, key: str, root: Any = None) -> None:
+    rev = f" (rev {inputs[key]['rev'][:7]})" if 'rev' in inputs[key] else ''
+    follows = (' - follows ' + '/'.join(inputs[key]['follows'])) if 'follows' in inputs[key] else ''
+    if root is None:
+        n = Node(f'{key} ')
+    else:
+        n = Node(f' {key}{rev}{follows} ', root)
+    if 'inputs' in inputs[key]:
+        for k in inputs[key]['inputs'].keys():
+            print_package_tree(inputs[key]['inputs'], k, n)
+
+    if root is None:
+        print_tree(n)
+
+
+# Computes all proper paths and "follows" paths.
+# When the user calls `kup shell <package> --override <path> ...`,
+# we most likely want the `<path>`` to be a proper path and not a follows path.
+# We should emit a warning only however, since the user may know better and
+# only wants to override the follow path
+def flatten_inputs_paths(inputs: dict) -> Tuple[List[Tuple[List[str], str]], List[Tuple[List[str], List[str]]]]:
+    flattened_proper = []
+    flattened_follow = []
+    for k in inputs.keys():
+        if 'follows' in inputs[k]:
+            flattened_follow.append(([k], inputs[k]['follows']))
+        elif 'inputs' in inputs[k]:
+            flattened_proper_k, flattened_follow_k = flatten_inputs_paths(inputs[k]['inputs'])
+            flattened_proper.extend(
+                [([k] + path, repo) for path, repo in flattened_proper_k]
+                if len(flattened_proper_k) > 0
+                else [([k], inputs[k]['repo'])]
+            )
+            flattened_follow.extend([([k] + path, proper_path) for path, proper_path in flattened_follow_k])
+    return flattened_proper, flattened_follow
 
 
 def reload_packages() -> None:
@@ -137,7 +239,12 @@ def reload_packages() -> None:
                     len(m['originalUrl'].removeprefix(f'github:runtimeverification/{available_package.repo}')) > 1
                 )
                 packages[name] = ConcretePackage(
-                    available_package.repo, available_package.package, status, version, immutable, idx
+                    available_package.repo,
+                    available_package.package,
+                    status,
+                    version,
+                    immutable,
+                    idx,
                 )
             else:
                 packages[name] = ConcretePackage(available_package.repo, available_package.package, LOCAL, index=idx)
@@ -166,7 +273,7 @@ def highlight_row(condition: bool, xs: List[str]) -> List[str]:
         return xs
 
 
-def list_package(package_name: str) -> None:
+def list_package(package_name: str, show_inputs: bool) -> None:
     reload_packages()
     if package_name != 'all':
         if package_name not in available_packages.keys():
@@ -177,31 +284,35 @@ def list_package(package_name: str) -> None:
             return
         listed_package = available_packages[package_name]
 
-        tags = requests.get(f'https://api.github.com/repos/runtimeverification/{listed_package.repo}/tags')
-        commits = requests.get(f'https://api.github.com/repos/runtimeverification/{listed_package.repo}/commits')
-        tagged_releases = {t['commit']['sha']: t for t in tags.json()}
-        all_releases = [
-            PackageVersion(
-                c['sha'],
-                c['commit']['message'],
-                tagged_releases[c['sha']]['name'] if c['sha'] in tagged_releases else None,
-                c['commit']['committer']['date'],
-            )
-            for c in commits.json()
-            if not c['commit']['message'].startswith("Merge remote-tracking branch 'origin/develop'")
-        ]
+        if show_inputs:
+            inputs = get_package_inputs(package_name, listed_package)
+            print_package_tree(inputs, package_name)
+        else:
+            tags = requests.get(f'https://api.github.com/repos/runtimeverification/{listed_package.repo}/tags')
+            commits = requests.get(f'https://api.github.com/repos/runtimeverification/{listed_package.repo}/commits')
+            tagged_releases = {t['commit']['sha']: t for t in tags.json()}
+            all_releases = [
+                PackageVersion(
+                    c['sha'],
+                    c['commit']['message'],
+                    tagged_releases[c['sha']]['name'] if c['sha'] in tagged_releases else None,
+                    c['commit']['committer']['date'],
+                )
+                for c in commits.json()
+                if not c['commit']['message'].startswith("Merge remote-tracking branch 'origin/develop'")
+            ]
 
-        installed_packages_sha = {p.version for p in packages.values()}
+            installed_packages_sha = {p.version for p in packages.values()}
 
-        table_data = [['Version \033[92m(installed)\033[0m', 'Commit', 'Message']] + [
-            highlight_row(
-                p.sha in installed_packages_sha,
-                [p.tag if p.tag else '', p.sha[:7], textwrap.shorten(p.message, width=50, placeholder='...')],
-            )
-            for p in all_releases
-        ]
-        table = SingleTable(table_data)
-        print(table.table)
+            table_data = [['Version \033[92m(installed)\033[0m', 'Commit', 'Message']] + [
+                highlight_row(
+                    p.sha in installed_packages_sha,
+                    [p.tag if p.tag else '', p.sha[:7], textwrap.shorten(p.message, width=50, placeholder='...')],
+                )
+                for p in all_releases
+            ]
+            table = SingleTable(table_data)
+            print(table.table)
     else:
         table_data = [
             ['Package', 'Installed version', 'Status'],
@@ -210,22 +321,71 @@ def list_package(package_name: str) -> None:
         print(table.table)
 
 
+def mk_path(path: str, version_or_path: Optional[str]) -> str:
+    if version_or_path:
+        if os.path.isdir(version_or_path):
+            return os.path.abspath(version_or_path)
+        else:
+            return path + '/' + version_or_path
+    else:
+        return path
+
+
+def mk_override_args(
+    package_name: str, package: Union[AvailablePackage, ConcretePackage], overrides: List[List[str]]
+) -> List[str]:
+    if not overrides:
+        return []
+    inputs = get_package_inputs(package_name, package)
+    valid_inps, overrides_inps = flatten_inputs_paths(inputs[package_name]['inputs'])
+    valid_inputs = {'/'.join(path): repo for path, repo in valid_inps}
+    overrides_inputs = [('/'.join(i), '/'.join(j)) for (i, j) in overrides_inps]
+
+    nix_overrides = []
+    for [input, version_or_path] in overrides:
+        override_input = next((override for (i, override) in overrides_inputs if i == input), None)
+        if input not in valid_inputs:
+            if override_input:
+                print(
+                    f"⚠️ \033[93mThe input '\033[94m{input}\033[93m' you are trying to override follows '\033[94m{override_input}\033[93m'.\n",
+                    f"You may want to call this command with '\033[94m--override {override_input}\033[93m' instead.\033[0m"
+                )
+            else:
+                print(
+                    f"❗ \033[91m'\033[94m{input}\033[91m' is not a valid input of the package '\033[94m{package_name}\033[91m'.\n",
+                    f"To see the valid inputs, run '\033[94mkup list {package_name} --inputs\033[91m'\033[0m",
+                )
+                sys.exit(1)
+        repo = valid_inputs[input] if not override_input else valid_inputs[override_input]
+        path = mk_path(f'github:runtimeverification/{repo}', version_or_path)
+        nix_overrides.append('--override-input')
+        nix_overrides.append(input)
+        nix_overrides.append(path)
+    # print(nix_overrides)
+    return nix_overrides
+
+
 def update_or_install_package(
-    package: Union[AvailablePackage, ConcretePackage], version: Optional[str], local_path: Optional[str]
+    package_name: str,
+    package: Union[AvailablePackage, ConcretePackage],
+    version: Optional[str],
+    package_overrides: List[List[str]],
 ) -> None:
-    version = '/' + version if version else ''
-    path = f'github:runtimeverification/{package.repo}{version}' if not local_path else local_path
+    path = mk_path(f'github:runtimeverification/{package.repo}', version)
+
     if type(package) is ConcretePackage:
-        if package.immutable or version or local_path:
+        if package.immutable or version or package_overrides:
             nix(['profile', 'remove', str(package.index)])
-            nix(['profile', 'install', f'{path}#{package.package}'])
+            overrides = mk_override_args(package_name, package, package_overrides) if package_overrides else []
+            nix(['profile', 'install', f'{path}#{package.package}'] + overrides)
         else:
             nix(['profile', 'upgrade', str(package.index)])
     else:
-        nix(['profile', 'install', f'{path}#{package.package}'])
+        overrides = mk_override_args(package_name, package, package_overrides) if package_overrides else []
+        nix(['profile', 'install', f'{path}#{package.package}'] + overrides)
 
 
-def install_package(package_name: str, package_version: Optional[str], local_path: Optional[str]) -> None:
+def install_package(package_name: str, package_version: Optional[str], package_overrides: List[List[str]]) -> None:
     reload_packages()
     if package_name not in available_packages.keys():
         print(
@@ -233,7 +393,7 @@ def install_package(package_name: str, package_version: Optional[str], local_pat
             "\033[0mUse '\033[92mkup list\033[0m' to see all the available packages."
         )
         return
-    if package_name in installed_packages and not (package_version or local_path):
+    if package_name in installed_packages and not package_version:
         print(
             f"❗ The package '\033[94m{package_name}\033[0m' is already installed.\n"
             "Use '\033[92mkup update {package_name}\033[0m' to update to the latest version."
@@ -241,13 +401,13 @@ def install_package(package_name: str, package_version: Optional[str], local_pat
         return
     if package_name in installed_packages:
         package = packages[package_name]
-        update_or_install_package(package, package_version, local_path)
+        update_or_install_package(package_name, package, package_version, package_overrides)
     else:
         new_package = available_packages[package_name]
-        update_or_install_package(new_package, package_version, local_path)
+        update_or_install_package(package_name, new_package, package_version, package_overrides)
 
 
-def update_package(package_name: str, package_version: Optional[str], local_path: Optional[str]) -> None:
+def update_package(package_name: str, package_version: Optional[str], package_overrides: List[List[str]]) -> None:
     reload_packages()
     if package_name not in available_packages.keys():
         print(
@@ -258,15 +418,15 @@ def update_package(package_name: str, package_version: Optional[str], local_path
     if package_name not in installed_packages:
         print(
             f"❗ The package '\033[94m{package_name}\033[0m' is not currently installed.\n"
-            "Use '\033[92mkup install {package_name}\033[0m' to install the latest version."
+            f"Use '\033[92mkup install {package_name}\033[0m' to install the latest version."
         )
         return
     package = packages[package_name]
-    if package.status == INSTALLED and not (package_version or local_path):
-        print(f"The package '\033[94m{package_name}\033[0m' is up to date.")
+    if package.status == INSTALLED and not package_version:
+        print(f"The package \'\033[94m{package_name}\033[0m\' is up to date.")
         return
 
-    update_or_install_package(package, package_version, local_path)
+    update_or_install_package(package_name, package, package_version, package_overrides)
 
 
 def remove_package(package_name: str) -> None:
@@ -298,7 +458,7 @@ def remove_package(package_name: str) -> None:
             pass
         else:
             sys.stdout.write("Please respond with '[y]es' or '[n]o'\n")
-            # in case the user selected a wrong opion we want to short-circuit and
+            # in case the user selected a wrong option we want to short-circuit and
             # not try to remove kup twice
             return remove_package(package_name)
     package = packages[package_name]
@@ -310,11 +470,12 @@ def main() -> None:
     subparser = parser.add_subparsers(dest='command')
     list = subparser.add_parser('list', help='Show the active and installed K semantics')
     list.add_argument('package', nargs='?', default='all', type=str)
+    list.add_argument('--inputs', action=BooleanOptionalAction)
 
     install = subparser.add_parser('install', help='Download and install the stated package')
     install.add_argument('package', type=str)
     install.add_argument('--version', type=str)
-    install.add_argument('--local', type=str)
+    install.add_argument('--override', type=str, nargs=2, action='append')
 
     uninstall = subparser.add_parser('remove', help="Remove the given package from the user's PATH")
     uninstall.add_argument('package', type=str)
@@ -322,21 +483,21 @@ def main() -> None:
     update = subparser.add_parser('update', help='Update the package to the latest version')
     update.add_argument('package', type=str)
     update.add_argument('--version', type=str)
-    update.add_argument('--local', type=str)
+    update.add_argument('--override', type=str, nargs=2, action='append')
 
     shell = subparser.add_parser('shell', help='Add the selected package to the current shell (temporary)')
     shell.add_argument('package', type=str)
     shell.add_argument('--version', type=str)
-    shell.add_argument('--local', type=str)
+    shell.add_argument('--override', type=str, nargs=2, action='append')
 
     args = parser.parse_args()
 
     if args.command == 'list':
-        list_package(args.package)
+        list_package(args.package, args.inputs)
     elif args.command == 'install':
-        install_package(args.package, args.version, args.local)
+        install_package(args.package, args.version, args.override)
     elif args.command == 'update':
-        update_package(args.package, args.version, args.local)
+        update_package(args.package, args.version, args.override)
     elif args.command == 'remove':
         remove_package(args.package)
     elif args.command == 'shell':
@@ -348,9 +509,9 @@ def main() -> None:
             )
             return
         temporary_package = available_packages[args.package]
-        version = '/' + args.version if args.version else ''
-        path = f'github:runtimeverification/{temporary_package.repo}{version}' if not args.local else args.local
-        nix_detach(['shell', f'{path}#{temporary_package.package}'])
+        path = mk_path(f'github:runtimeverification/{temporary_package.repo}', args.version)
+        overrides = mk_override_args(args.package, temporary_package, args.override)
+        nix_detach(['shell', f'{path}#{temporary_package.package}'] + overrides)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a feature which allows manual overriding of all the upstream dependencies of any package, hosted in `runtimeverification` repos. To see all such dependencies for a package, call `kup list <package> --inputs`. E.g. for `kevm` we have:

```bash
kup list kevm --inputs                                 
      ┌ blockchain-k-plugin (rev 8fdc74e) 
      ├ haskell-backend - follows k-framework/haskell-backend 
      ├ pyk (rev d14865c) 
      ├ rv-utils_2 (rev 7026604) 
 kevm ┤
      │                           ┌ haskell-backend (rev 4c3c436) 
      │                           ├ rv-utils (rev 7026604) 
      └ k-framework (rev 08eda3c) ┤
                                  └ llvm-backend (rev 94e8f4b) ┐
                                                               └ immer-src (rev 198c2ae) 
```

If we want to override e.g. the `immer-src` input dependency, we can call

```
kup install kevm --override k-framework/llvm-backend/immer-src ~git/immer-src
```

Note that we can pass in either a local file path or a git hash/tag.

This PR also removes the `--local` argument for install/update/shell as its now clever enough to figure out when `--version` is passed a file path vs a git hash/tag