### PR TITLE
Add warning when current user isn't trusted by nix

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -114,7 +114,7 @@ def nix(args: List[str], is_install: bool = True) -> bytes:
         print_substituters_warning()
     return nix_raw(
         args,
-        NIX_SUBSTITUTERS if is_install and not CONTAINS_SUBSTITUTERS else [],
+        NIX_SUBSTITUTERS if is_install and not CONTAINS_SUBSTITUTERS and IS_TRUSTED_USER else [],
         True if 'darwin' in SYSTEM else False,
     )
 
@@ -126,7 +126,7 @@ def nix_detach(args: List[str]) -> None:
     nix = subprocess.check_output(['which', 'nix']).decode('utf8').strip()
     if not IS_TRUSTED_USER and not CONTAINS_SUBSTITUTERS:
         print_substituters_warning()
-    extra_flags = NIX_SUBSTITUTERS if not CONTAINS_SUBSTITUTERS else []
+    extra_flags = NIX_SUBSTITUTERS if not CONTAINS_SUBSTITUTERS and IS_TRUSTED_USER else []
     os.execve(nix, [nix] + args + ['--extra-experimental-features', 'nix-command flakes'] + extra_flags, my_env)
 
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -69,19 +69,23 @@ def check_substituters() -> Tuple[bool, bool]:
     try:
         result = nix_raw(['show-config', '--json'], extra_flags=[])
     except Exception:
-        rich.print("❗ [red]Internal error. Could not run 'nix show-config'.")
-        sys.exit(1)
+        rich.print("⚠️ [yellow]Could not run 'nix show-config'.")
+        return False, False
     config = json.loads(result)
-    TRUSTED_USERS = config['trusted-users']['value']
-    current_user_is_trusted = True if USER in TRUSTED_USERS else False
-    substituters = config['substituters']['value']
-    has_all_substituters = (
-        True
-        if 'https://k-framework.cachix.org' in substituters
-        and ('https://cache.iog.io' in substituters or 'https://hydra.iohk.io' in substituters)
-        else False
-    )
-    return current_user_is_trusted, has_all_substituters
+    try:
+        TRUSTED_USERS = config['trusted-users']['value']
+        current_user_is_trusted = True if USER in TRUSTED_USERS else False
+        substituters = config['substituters']['value']
+        has_all_substituters = (
+            True
+            if 'https://k-framework.cachix.org' in substituters
+            and ('https://cache.iog.io' in substituters or 'https://hydra.iohk.io' in substituters)
+            else False
+        )
+        return current_user_is_trusted, has_all_substituters
+    except Exception:
+        rich.print('⚠️ [yellow]Could not fetch nix substituters or figure out if the current user is trusted by nix.')
+        return False, False
 
 
 IS_TRUSTED_USER, CONTAINS_SUBSTITUTERS = check_substituters()

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -17,7 +17,7 @@ from terminaltables import SingleTable  # type: ignore
 
 console = Console(theme=Theme({'markdown.code': 'green'}))
 
-SCRIPT_DIR = os.path.split(os.path.abspath(__file__))[0]  # i.e. /path/to/dir/
+KUP_DIR = os.path.split(os.path.abspath(__file__))[0]  # i.e. /path/to/dir/
 USER = pwd.getpwuid(os.getuid())[0]
 
 INSTALLED = '🟢 \033[92minstalled\033[0m'
@@ -105,7 +105,8 @@ def print_substituters_warning() -> None:
         '   Nix will also look for [green]nix/nix.conf[/] files in [green]XDG_CONFIG_DIRS[/] and [green]XDG_CONFIG_HOME[/].\n'
         '   If unset, [green]XDG_CONFIG_DIRS[/] defaults to [green]/etc/xdg[/], and [green]XDG_CONFIG_HOME[/] defaults to [green]$HOME/.config[/]\n'
         '   as per XDG Base Directory Specification.\n\n'
-        'b) Re-run this command as root. ([red]not recommended[/])\n\n'
+        'b) Re-run this command as root. [red](not recommended)[/]\n\n\n'
+        'For more information on the nix config file, see: https://nixos.org/manual/nix/stable/command-ref/conf-file.html\n'
     )
 
 
@@ -114,8 +115,8 @@ def print_substituters_warning() -> None:
 # expression. This may cause the process to run out of memory, but hasn't been observed for our
 # derivations in practice, so should be ok to do.
 def nix(args: List[str], is_install: bool = True) -> bytes:
-    if is_install and not IS_TRUSTED_USER and not CONTAINS_SUBSTITUTERS:
-        print_substituters_warning()
+    # if is_install and not IS_TRUSTED_USER and not CONTAINS_SUBSTITUTERS:
+    print_substituters_warning()
     return nix_raw(
         args,
         NIX_SUBSTITUTERS if is_install and not CONTAINS_SUBSTITUTERS and IS_TRUSTED_USER else [],
@@ -541,7 +542,7 @@ def remove_package(package_name: str) -> None:
 def print_help(subcommand: str, parser: ArgumentParser) -> None:
     parser.print_help()
     print('')
-    with open(os.path.join(SCRIPT_DIR, f'{subcommand}-help.md'), 'r') as help_file:
+    with open(os.path.join(KUP_DIR, f'{subcommand}-help.md'), 'r') as help_file:
         console.print(Markdown(help_file.read(), code_theme='emacs'))
     parser.exit()
 
@@ -624,7 +625,7 @@ def main() -> None:
 
     args = parser.parse_args()
     if 'help' in args and args.help:
-        with open(os.path.join(SCRIPT_DIR, f'{args.command}-help.md'), 'r+') as help_file:
+        with open(os.path.join(KUP_DIR, f'{args.command}-help.md'), 'r+') as help_file:
             console.print(Markdown(help_file.read(), code_theme='emacs'))
             sys.exit(0)
     if args.command == 'list':

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -115,8 +115,8 @@ def print_substituters_warning() -> None:
 # expression. This may cause the process to run out of memory, but hasn't been observed for our
 # derivations in practice, so should be ok to do.
 def nix(args: List[str], is_install: bool = True) -> bytes:
-    # if is_install and not IS_TRUSTED_USER and not CONTAINS_SUBSTITUTERS:
-    print_substituters_warning()
+    if is_install and not IS_TRUSTED_USER and not CONTAINS_SUBSTITUTERS:
+        print_substituters_warning()
     return nix_raw(
         args,
         NIX_SUBSTITUTERS if is_install and not CONTAINS_SUBSTITUTERS and IS_TRUSTED_USER else [],


### PR DESCRIPTION
Fixes #13

We now check if the current user is a trusted nix user and/or if the substituters we want to use are already present. If neither is true, the following message will be printed when trying to install a package, giving the user options of how to fix the issue. 

<img width="827" alt="image" src="https://user-images.githubusercontent.com/10553895/200017814-33bbbed9-1dd9-461b-84e1-145bd30e615a.png">

However, since the command will still succeed without the substituters this only shows as a warning and not an error