### PR TITLE
Add missing caches with possible authentication when adding new package

### DIFF
--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 
 class GithubPackage:
-    __slots__ = ['org', 'repo', 'package', 'branch', 'private', 'access_token']
+    __slots__ = ['org', 'repo', 'package', 'branch', 'ssh_git', 'access_token']
 
     def __init__(
         self,
@@ -10,14 +10,14 @@ class GithubPackage:
         repo: str,
         package: str,
         branch: Optional[str] = None,
-        private: bool = False,
+        ssh_git: bool = False,
         access_token: Optional[str] = None,
     ):
         self.org = org
         self.repo = repo
         self.package = package
         self.branch = branch
-        self.private = private
+        self.ssh_git = ssh_git
         self.access_token = access_token
 
 
@@ -31,7 +31,7 @@ class ConcretePackage(GithubPackage):
         'immutable',
         'index',
         'branch',
-        'private',
+        'ssh_git',
         'access_token',
     ]
 
@@ -45,14 +45,14 @@ class ConcretePackage(GithubPackage):
         immutable: bool = True,
         index: int = -1,
         branch: Optional[str] = None,
-        private: bool = False,
+        ssh_git: bool = False,
         access_token: Optional[str] = None,
     ):
         self.version = version
         self.status = status
         self.immutable = immutable
         self.index = index
-        super().__init__(org, repo, package, branch, private, access_token)
+        super().__init__(org, repo, package, branch, ssh_git, access_token)
 
 
 class PackageVersion:


### PR DESCRIPTION
This PR adds the ability to add extra caches specified in the flake's `nixConf` field. kup will read this data and add any caches which are not present on the system but are specified by the package. kup will also handle adding the appropriate auth tokens for private caches.