### PR TITLE
Clean up CLI parser + instal//update command

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -420,7 +420,7 @@ def install_or_update_package(
     is_update: bool = False,
 ) -> None:
     reload_packages()
-    if package_name not in available_packages.keys():
+    if package_name not in available_packages:
         rich.print(
             f"❗ [red]The package '[green]{package_name}[/]' does not exist.\n"
             "[/]Use '[blue]kup list[/]' to see all the available packages."

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -808,7 +808,7 @@ def main() -> None:
         if not USER_IS_TRUSTED and not CONTAINS_DEFAULT_SUBSTITUTER:
             print()
             ask_install_substituters('k-framework', [K_FRAMEWORK_CACHE], [K_FRAMEWORK_PUBLIC_KEY])
-    elif args.command == 'install' or args.command == 'update':
+    elif args.command in {'install', 'update'}:
         install_or_update_package(
             args.package, args.version, args.override, args.verbose, args.refresh, is_update=args.command == 'update'
         )


### PR DESCRIPTION
Based on feedback from @jberthold (#37) I have essentailly merged the install and update command. There is now no distinction between

```
kup install k
```

and 

```
kup update k
```

if `k` is already installed. I have also dropped previous checks and messages about when a package is up to date because the logic wasn't correct wrt overrides. Having no checks means delegating the logic onto nix which is an acceptable tradeoff imo, as it makes our code easier to read and more importantly, correct and more flexible.

This PR also fixes #36, by making a shared argument parser between the install/update/shell subcommands.