### PR TITLE
Call `update-input` when overriding an input

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -399,6 +399,8 @@ def mk_override_args(package_name: str, package: GithubPackage, overrides: List[
         nix_overrides.append('--override-input')
         nix_overrides.append(input)
         nix_overrides.append(path)
+        nix_overrides.append('--update-input')
+        nix_overrides.append(input)
     return nix_overrides
 
 


### PR DESCRIPTION
For some reason nix does not automatically adjust transitive dependenices when overriding an input. This PR makes sure this happens by turning

```
kup shell k --override haskell-backend $foo
```

into

```
nix shell github:runtimeverification/k --override-input haskell-backend $foo --update-input haskell-backend
```

(before the command issued by kup was only `nix shell github:runtimeverification/k --override-input haskell-backend $foo`)