### PR TITLE
Bump install nix action

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: 'Install Nix/Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v3
       - name: 'Install Nix/Cachix'
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v22
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config:


### PR DESCRIPTION
Currently, the Nix flake release [job fails](https://github.com/runtimeverification/kup/actions/runs/5747585408) on macos-12. Perhaps updating the action we use to install Nix fixes that?