### PR TITLE
Enable packages with extensions

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -193,7 +193,7 @@ def package_metadata_tree(p: Union[PackageMetadata, Follows], lbl: Union[str, No
     if lbl is None:
         tree = Tree('Inputs:')
     else:
-        rev = f' - github:{p.org}/{p.repo} [green]{p.rev[:7]}[/]' if type(p) == PackageMetadata else ''
+        rev = f' - github:{p.org}/{p.repo}' if type(p) == PackageMetadata else ''
         follows = (' - follows [green]' + '/'.join(p.follows)) if type(p) == Follows else ''
         tree = Tree(f'{lbl}{rev}{follows}')
     if type(p) == PackageMetadata:

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -32,7 +32,7 @@ from .nix import (
     nix_detach,
     set_netrc_file,
 )
-from .package import ConcretePackage, Follows, GithubPackage, PackageMetadata, PackageVersion
+from .package import ConcretePackage, Follows, GithubPackage, PackageMetadata, PackageName, PackageVersion
 
 console = Console(theme=Theme({'markdown.code': 'green'}))
 
@@ -44,15 +44,15 @@ UPDATE = '🟠 \033[93mnewer version available\033[0m'
 LOCAL = '\033[3mlocal checkout\033[0m'
 
 available_packages: Dict[str, GithubPackage] = {
-    'kup': GithubPackage('runtimeverification', 'kup', 'kup'),
-    'k': GithubPackage('runtimeverification', 'k', 'k'),
-    'kavm': GithubPackage('runtimeverification', 'avm-semantics', 'kavm'),
-    'kevm': GithubPackage('runtimeverification', 'evm-semantics', 'kevm'),
-    'kplutus': GithubPackage('runtimeverification', 'plutus-core-semantics', 'kplutus'),
-    'kore-exec': GithubPackage('runtimeverification', 'haskell-backend', 'kore:exe:kore-exec'),
-    'kore-rpc': GithubPackage('runtimeverification', 'haskell-backend', 'kore:exe:kore-rpc'),
-    'pyk': GithubPackage('runtimeverification', 'pyk', 'pyk'),
-    'booster': GithubPackage('runtimeverification', 'hs-backend-booster', 'booster', 'main'),
+    'kup': GithubPackage('runtimeverification', 'kup', PackageName('kup')),
+    'k': GithubPackage('runtimeverification', 'k', PackageName('k')),
+    'kavm': GithubPackage('runtimeverification', 'avm-semantics', PackageName('kavm')),
+    'kevm': GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm')),
+    'kplutus': GithubPackage('runtimeverification', 'plutus-core-semantics', PackageName('kplutus')),
+    'kore-exec': GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore:exe:kore-exec')),
+    'kore-rpc': GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore:exe:kore-rpc')),
+    'pyk': GithubPackage('runtimeverification', 'pyk', PackageName('pyk')),
+    'booster': GithubPackage('runtimeverification', 'hs-backend-booster', PackageName('booster'), 'main'),
 }
 
 # Load any private packages
@@ -61,25 +61,25 @@ for config_path in BaseDirectory.load_config_paths('kup'):
         config = configparser.ConfigParser()
 
         config.read(os.path.join(config_path, 'user_packages.ini'))
-        for pkg_name in config.sections():
+        for pkg_alias in config.sections():
             substituters = (
-                [s.strip() for s in config[pkg_name]['substituters'].split(' ')]
-                if 'substituters' in config[pkg_name]
+                [s.strip() for s in config[pkg_alias]['substituters'].split(' ')]
+                if 'substituters' in config[pkg_alias]
                 else []
             )
             public_keys = (
-                [k.strip() for k in config[pkg_name]['public_keys'].split(' ')]
-                if 'public_keys' in config[pkg_name]
+                [k.strip() for k in config[pkg_alias]['public_keys'].split(' ')]
+                if 'public_keys' in config[pkg_alias]
                 else []
             )
 
-            available_packages[pkg_name] = GithubPackage(
-                config[pkg_name]['org'],
-                config[pkg_name]['repo'],
-                config[pkg_name]['package'],
-                config[pkg_name]['branch'] if 'branch' in config[pkg_name] else None,
-                (config[pkg_name]['ssh+git'].lower() == 'true') if 'ssh+git' in config[pkg_name] else False,
-                config[pkg_name]['github-access-token'] if 'github-access-token' in config[pkg_name] else None,
+            available_packages[pkg_alias] = GithubPackage(
+                config[pkg_alias]['org'],
+                config[pkg_alias]['repo'],
+                PackageName.parse(config[pkg_alias]['package']),
+                config[pkg_alias]['branch'] if 'branch' in config[pkg_alias] else None,
+                (config[pkg_alias]['ssh+git'].lower() == 'true') if 'ssh+git' in config[pkg_alias] else False,
+                config[pkg_alias]['github-access-token'] if 'github-access-token' in config[pkg_alias] else None,
                 substituters,
                 public_keys,
             )
@@ -202,6 +202,26 @@ def package_metadata_tree(p: Union[PackageMetadata, Follows], lbl: Union[str, No
     return tree
 
 
+def lookup_available_package(raw_name: str) -> Optional[Tuple[str, GithubPackage]]:
+    for alias, p in available_packages.items():
+        name_prefix = f'packages.{SYSTEM}.{p.package.base}'
+        if raw_name.startswith(name_prefix):
+            ext_str = raw_name.removeprefix(name_prefix)
+            ext_str = ext_str.removeprefix('.').strip()
+            ext = ext_str.split('.') if ext_str != '' else []
+            return alias, GithubPackage(
+                p.org,
+                p.repo,
+                PackageName(p.package.base, ext),
+                p.branch,
+                p.ssh_git,
+                p.access_token,
+                p.substituters,
+                p.public_keys,
+            )
+    return None
+
+
 def reload_packages(load_versions: bool = True) -> None:
     global packages, installed_packages
 
@@ -213,58 +233,58 @@ def reload_packages(load_versions: bool = True) -> None:
         manifest = []
 
     packages = {}
-    available_packages_lookup = {f'packages.{SYSTEM}.{p.package}': (key, p) for key, p in available_packages.items()}
 
     for idx, m in enumerate(manifest):
-        if 'attrPath' in m and m['attrPath'] in available_packages_lookup:
-            (name, available_package) = available_packages_lookup[m['attrPath']]
-            repo_path, _ = mk_github_repo_path(available_package)
-            if 'originalUrl' in m and m['originalUrl'].startswith(repo_path):
-                if available_package.ssh_git:
-                    version = m['url'].split('&rev=')[1]
-                    immutable = 'rev=' in m['originalUrl'] or 'ref=' in m['originalUrl']
-                    tag = None
-                else:
-                    version = m['url'].removeprefix(f'github:{available_package.org}/{available_package.repo}/')
-                    maybe_tag = m['originalUrl'].removeprefix(
-                        f'github:{available_package.org}/{available_package.repo}'
-                    )
-                    if len(maybe_tag) > 1:
-                        immutable = True
-                        tag = maybe_tag.removeprefix('/')
-                    else:
-                        immutable = False
+        if 'attrPath' in m and m['attrPath']:
+            res = lookup_available_package(m['attrPath'])
+            if res is not None:
+                alias, available_package = res
+                repo_path, _ = mk_github_repo_path(available_package)
+                if 'originalUrl' in m and m['originalUrl'].startswith(repo_path):
+                    if available_package.ssh_git:
+                        version = m['url'].split('&rev=')[1]
+                        immutable = 'rev=' in m['originalUrl'] or 'ref=' in m['originalUrl']
                         tag = None
+                    else:
+                        version = m['url'].removeprefix(f'github:{available_package.org}/{available_package.repo}/')
+                        maybe_tag = m['originalUrl'].removeprefix(
+                            f'github:{available_package.org}/{available_package.repo}'
+                        )
+                        if len(maybe_tag) > 1:
+                            immutable = True
+                            tag = maybe_tag.removeprefix('/')
+                        else:
+                            immutable = False
+                            tag = None
 
-                status = check_package_version(available_package, m['url']) if load_versions else ''
-                packages[name] = ConcretePackage(
-                    available_package.org,
-                    available_package.repo,
-                    available_package.package,
-                    status,
-                    version,
-                    immutable,
-                    idx,
-                    available_package.branch,
-                    available_package.ssh_git,
-                    tag=tag,
-                )
-            else:
-                packages[name] = ConcretePackage(
-                    available_package.org,
-                    available_package.repo,
-                    available_package.package,
-                    LOCAL,
-                    index=idx,
-                    branch=available_package.branch,
-                    ssh_git=available_package.ssh_git,
-                )
+                    status = check_package_version(available_package, m['url']) if load_versions else ''
+                    packages[alias] = ConcretePackage(
+                        available_package.org,
+                        available_package.repo,
+                        available_package.package,
+                        status,
+                        version,
+                        immutable,
+                        idx,
+                        available_package.branch,
+                        available_package.ssh_git,
+                        tag=tag,
+                    )
+                else:
+                    packages[alias] = ConcretePackage(
+                        available_package.org,
+                        available_package.repo,
+                        available_package.package,
+                        LOCAL,
+                        index=idx,
+                        branch=available_package.branch,
+                        ssh_git=available_package.ssh_git,
+                    )
 
-    installed_packages = list(packages.keys())
-    for pkg_name in available_packages:
-        if pkg_name not in installed_packages:
-            available_package = available_packages[pkg_name]
-            packages[pkg_name] = ConcretePackage(
+    installed_packages = [p.package.base for p in packages.values()]
+    for pkg_alias, available_package in available_packages.items():
+        if available_package.package.base not in installed_packages:
+            packages[pkg_alias] = ConcretePackage(
                 available_package.org,
                 available_package.repo,
                 available_package.package,
@@ -282,16 +302,16 @@ def highlight_row(condition: bool, xs: List[str]) -> List[str]:
         return xs
 
 
-def list_package(package_name: str, show_inputs: bool) -> None:
+def list_package(package_alias: str, show_inputs: bool) -> None:
     reload_packages()
-    if package_name != 'all':
-        if package_name not in available_packages.keys():
+    if package_alias != 'all':
+        if package_alias not in available_packages.keys():
             rich.print(
-                f"❗ [red]The package '[green]{package_name}[/]' does not exist.\n"
+                f"❗ [red]The package '[green]{package_alias}[/]' does not exist.\n"
                 "[/]Use '[blue]kup list[/]' to see all the available packages."
             )
             return
-        listed_package = available_packages[package_name]
+        listed_package = available_packages[package_alias]
 
         if show_inputs:
             inputs = get_package_metadata(listed_package)
@@ -331,9 +351,14 @@ def list_package(package_name: str, show_inputs: bool) -> None:
             table = SingleTable(table_data)
             print(table.table)
     else:
-        table_data = [
-            ['Package', 'Installed version', 'Status'],
-        ] + [[name, f'{p.version}{" (" + p.tag + ")" if p.tag else ""}', p.status] for name, p in packages.items()]
+        table_data = [['Package name (alias)', 'Installed version', 'Status'],] + [
+            [
+                PackageName(alias, p.package.ext).to_string(),
+                f'{p.version}{" (" + p.tag + ")" if p.tag else ""}',
+                p.status,
+            ]
+            for alias, p in packages.items()
+        ]
         table = SingleTable(table_data)
         print(table.table)
 
@@ -367,7 +392,7 @@ def walk_package_metadata(
             return None
 
 
-def mk_override_args(package_name: str, package: GithubPackage, overrides: List[List[str]]) -> List[str]:
+def mk_override_args(package_alias: str, package: GithubPackage, overrides: List[List[str]]) -> List[str]:
     if not overrides:
         return []
     inputs = get_package_metadata(package)
@@ -386,14 +411,14 @@ def mk_override_args(package_name: str, package: GithubPackage, overrides: List[
             possible_input = walk_package_metadata(inputs, input_path)
         if possible_input is None:
             rich.print(
-                f"❗ [red]'[green]{input}[/]' is not a valid input of the package '[green]{package_name}[/]'.\n"
-                f"[/]To see the valid inputs, run '[blue]kup list {package_name} --inputs[/]'"
+                f"❗ [red]'[green]{input}[/]' is not a valid input of the package '[green]{package_alias}[/]'.\n"
+                f"[/]To see the valid inputs, run '[blue]kup list {package_alias} --inputs[/]'"
             )
             sys.exit(1)
 
         if type(possible_input) == PackageMetadata:
             repo = possible_input.repo
-            git_path, _ = mk_path_package(GithubPackage('runtimeverification', repo, ''), version_or_path)
+            git_path, _ = mk_path_package(GithubPackage('runtimeverification', repo, PackageName('')), version_or_path)
             nix_overrides.append('--override-input')
             nix_overrides.append('/'.join(input_path))
             nix_overrides.append(git_path)
@@ -408,7 +433,8 @@ def mk_override_args(package_name: str, package: GithubPackage, overrides: List[
 
 
 def install_or_update_package(
-    package_name: str,
+    package_alias: str,
+    package_ext: list[str],
     package_version: Optional[str],
     package_overrides: List[List[str]],
     verbose: bool,
@@ -416,34 +442,37 @@ def install_or_update_package(
     is_update: bool = False,
 ) -> None:
     reload_packages()
-    if package_name not in available_packages:
+    if package_alias not in available_packages:
         rich.print(
-            f"❗ [red]The package '[green]{package_name}[/]' does not exist.\n"
+            f"❗ [red]The package '[green]{package_alias}[/]' does not exist.\n"
             "[/]Use '[blue]kup list[/]' to see all the available packages."
         )
         return
-    if is_update and package_name not in installed_packages:
+    if is_update and package_alias not in installed_packages:
         rich.print(
-            f"❗ [red]The package '[green]{package_name}[/]' is not currently installed.\n"
-            f"[/]Use '[blue]kup install {package_name}[/]' to install the latest version."
+            f"❗ [red]The package '[green]{package_alias}[/]' is not currently installed.\n"
+            f"[/]Use '[blue]kup install {package_alias}[/]' to install the latest version."
         )
         return
 
-    if package_name in installed_packages:
-        package: GithubPackage = packages[package_name]
+    if package_alias in installed_packages:
+        package: GithubPackage = packages[package_alias]
     else:
-        package = available_packages[package_name]
+        package = available_packages[package_alias]
 
     path, git_token_options = mk_path_package(package, package_version)
-    overrides = mk_override_args(package_name, package, package_overrides) if package_overrides else []
+    overrides = mk_override_args(package_alias, package, package_overrides) if package_overrides else []
+
+    # we build the actual package name from the base name of the found package plus any extensions passed to this function
+    package_name = PackageName(package.package.base, package_ext)
 
     if type(package) is ConcretePackage:
-        if package.immutable or package_version or package_overrides:
+        if package.immutable or package_version or package_overrides or package_ext != package.package.ext:
             # we first attempt to build the package before deleting the old one form the profile, to avoid
             # a situation where we delete the old package and then fail to build the new one. This is
             # especially awkward when updating kup
             nix(
-                ['build', f'{path}#{package.package}', '--no-link'] + overrides + git_token_options,
+                ['build', f'{path}#{package_name.to_string()}', '--no-link'] + overrides + git_token_options,
                 extra_substituters=package.substituters,
                 extra_public_keys=package.public_keys,
                 verbose=verbose,
@@ -451,7 +480,7 @@ def install_or_update_package(
             )
             nix(['profile', 'remove', str(package.index)], is_install=False)
             nix(
-                ['profile', 'install', f'{path}#{package.package}'] + overrides + git_token_options,
+                ['profile', 'install', f'{path}#{package_name.to_string()}'] + overrides + git_token_options,
                 extra_substituters=package.substituters,
                 extra_public_keys=package.public_keys,
                 verbose=verbose,
@@ -466,30 +495,31 @@ def install_or_update_package(
             )
     else:
         nix(
-            ['profile', 'install', f'{path}#{package.package}'] + overrides + git_token_options,
+            ['profile', 'install', f'{path}#{package_name.to_string()}'] + overrides + git_token_options,
             extra_substituters=package.substituters,
             extra_public_keys=package.public_keys,
             verbose=verbose,
             refresh=refresh,
         )
 
-    verb = 'updated' if package_name in installed_packages else 'installed'
-    rich.print(f" ✅ Successfully {verb} '[green]{package_name}[/]'.")
+    verb = 'updated' if package_alias in installed_packages else 'installed'
+    display_version = f' ({package_version})' if package_version else ' (master)'
+    rich.print(f" ✅ Successfully {verb} '[green]{package_alias}[/]' to version [blue]{package_name.to_string()}{display_version}[/].")
 
 
-def remove_package(package_name: str) -> None:
+def remove_package(package_alias: str) -> None:
     reload_packages(load_versions=False)
-    if package_name not in available_packages.keys():
+    if package_alias not in available_packages.keys():
         rich.print(
-            f"❗ [red]The package '[green]{package_name}[/]' does not exist.\n"
+            f"❗ [red]The package '[green]{package_alias}[/]' does not exist.\n"
             "[/]Use '[blue]kup list[/]' to see all the available packages."
         )
         return
-    if package_name not in installed_packages:
-        rich.print(f"❗ The package '[green]{package_name}[/]' is not currently installed.")
+    if package_alias not in installed_packages:
+        rich.print(f"❗ The package '[green]{package_alias}[/]' is not currently installed.")
         return
 
-    if package_name == 'kup' and len(installed_packages) > 1:
+    if package_alias == 'kup' and len(installed_packages) > 1:
         rich.print(
             "⚠️ [yellow]You are about to remove '[green]kup[/]' "
             'with other K framework packages still installed.\n'
@@ -508,8 +538,8 @@ def remove_package(package_name: str) -> None:
             sys.stdout.write("Please respond with '[y]es' or '[n]o'\n")
             # in case the user selected a wrong option we want to short-circuit and
             # not try to remove kup twice
-            return remove_package(package_name)
-    package = packages[package_name]
+            return remove_package(package_alias)
+    package = packages[package_alias]
     nix(['profile', 'remove', str(package.index)], is_install=False)
 
 
@@ -545,7 +575,7 @@ def check_github_api_accessible(org: str, repo: str, access_token: Optional[str]
 def add_new_package(
     name: str,
     uri: str,
-    package: str,
+    package: PackageName,
     github_access_token: Optional[str],
     cache_access_tokens: Dict[str, str],
     strict: bool,
@@ -611,7 +641,7 @@ def add_new_package(
         config[name] = {
             'org': new_package.org,
             'repo': new_package.repo,
-            'package': new_package.package,
+            'package': new_package.package.to_string(),
             'ssh+git': str(new_package.ssh_git),
             'substituters': ' '.join(substituters),
             'public_keys': ' '.join(trusted_public_keys),
@@ -797,12 +827,15 @@ def main() -> None:
     add.add_argument('-h', '--help', action=_HelpAddAction)
 
     args = parser.parse_args()
+    alias_with_ext = PackageName.parse(args.package)
+    alias, ext = alias_with_ext.base, alias_with_ext.ext
+
     if 'help' in args and args.help:
         with open(os.path.join(KUP_DIR, f'{args.command}-help.md'), 'r+') as help_file:
             console.print(Markdown(help_file.read(), code_theme='emacs'))
             sys.exit(0)
     if args.command == 'list':
-        list_package(args.package, args.inputs)
+        list_package(alias, args.inputs)
     elif args.command == 'doctor':
         trusted_check = '🟢' if USER_IS_TRUSTED else '🟠'
         substituter_check = '🟢' if CONTAINS_DEFAULT_SUBSTITUTER else ('🟢' if USER_IS_TRUSTED else '🔴')
@@ -815,32 +848,40 @@ def main() -> None:
             ask_install_substituters('k-framework', [K_FRAMEWORK_CACHE], [K_FRAMEWORK_PUBLIC_KEY])
     elif args.command in {'install', 'update'}:
         install_or_update_package(
-            args.package, args.version, args.override, args.verbose, args.refresh, is_update=args.command == 'update'
+            alias, ext, args.version, args.override, args.verbose, args.refresh, is_update=args.command == 'update'
         )
     elif args.command == 'remove':
-        remove_package(args.package)
+        remove_package(alias)
     elif args.command == 'add':
         add_new_package(
             args.name,
             args.uri,
-            args.package,
+            PackageName.parse(args.package),
             args.github_access_token,
             {repo: key for [repo, key] in args.cache_access_token} if args.cache_access_token else {},
             args.strict,
         )
     elif args.command == 'shell':
         reload_packages(load_versions=False)
-        if args.package not in available_packages.keys():
+        if alias not in available_packages.keys():
             rich.print(
-                f"❗ [red]The package '[green]{args.package}[/]' does not exist.\n"
+                f"❗ [red]The package '[green]{alias}[/]' does not exist.\n"
                 "[/]Use '[blue]kup list[/]' to see all the available packages."
             )
             return
-        temporary_package = available_packages[args.package]
+        if alias in installed_packages:
+            rich.print(
+                f"❗ [red]The package '[green]{alias}[/]' is currently installed and thus cannot be temporarily added to the PATH.\n"
+                "[/]Use:\n * '[blue]kup update {alias} ...[/]' to replace the installed version or\n * '[blue]kup remove {alias}[/]' to remove the installed version and then re-run this command"
+            )
+            return
+        temporary_package = available_packages[alias]
         path, git_token_options = mk_path_package(temporary_package, args.version)
-        overrides = mk_override_args(args.package, temporary_package, args.override)
+        overrides = mk_override_args(alias, temporary_package, args.override)
+        # combine the actual package name with the possible extensions
+        package_name = PackageName(temporary_package.package.base, ext)
         nix_detach(
-            ['shell', f'{path}#{temporary_package.package}'] + overrides + git_token_options,
+            ['shell', f'{path}#{package_name.to_string()}'] + overrides + git_token_options,
             extra_substituters=temporary_package.substituters,
             extra_public_keys=temporary_package.public_keys,
             verbose=args.verbose,

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -504,7 +504,9 @@ def install_or_update_package(
 
     verb = 'updated' if package_alias in installed_packages else 'installed'
     display_version = f' ({package_version})' if package_version else ' (master)'
-    rich.print(f" ✅ Successfully {verb} '[green]{package_alias}[/]' to version [blue]{package_name.to_string()}{display_version}[/].")
+    rich.print(
+        f" ✅ Successfully {verb} '[green]{package_alias}[/]' to version [blue]{package_name.to_string()}{display_version}[/]."
+    )
 
 
 def remove_package(package_alias: str) -> None:

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -1,6 +1,26 @@
 from typing import Mapping, Optional, Union
 
 
+class PackageName:
+    __slots__ = ['base', 'ext']
+
+    def __init__(
+        self,
+        base: str,
+        ext: Optional[list[str]] = None,
+    ):
+        self.base = base
+        self.ext = ext if ext is not None else []
+
+    def to_string(self) -> str:
+        return '.'.join([self.base] + self.ext)
+
+    @staticmethod
+    def parse(name: str) -> 'PackageName':
+        s = name.split('.')
+        return PackageName(s[0], s[1:])
+
+
 class GithubPackage:
     __slots__ = ['org', 'repo', 'package', 'branch', 'ssh_git', 'access_token', 'substituters', 'public_keys']
 
@@ -8,7 +28,7 @@ class GithubPackage:
         self,
         org: str,
         repo: str,
-        package: str,
+        package: PackageName,
         branch: Optional[str] = None,
         ssh_git: bool = False,
         access_token: Optional[str] = None,
@@ -46,7 +66,7 @@ class ConcretePackage(GithubPackage):
         self,
         org: str,
         repo: str,
-        package: str,
+        package: PackageName,
         status: str,
         version: str = '-',
         immutable: bool = True,

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -1,19 +1,18 @@
-from typing import Mapping, Optional, Union
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional, Union
 
 
+@dataclass(frozen=True)
 class PackageName:
-    __slots__ = ['base', 'ext']
+    base: str
+    ext: tuple[str, ...]
 
-    def __init__(
-        self,
-        base: str,
-        ext: Optional[list[str]] = None,
-    ):
-        self.base = base
-        self.ext = ext if ext is not None else []
+    def __init__(self, base: str, ext: Iterable[str] = ()):
+        object.__setattr__(self, 'base', base)
+        object.__setattr__(self, 'ext', tuple(ext))
 
-    def to_string(self) -> str:
-        return '.'.join([self.base] + self.ext)
+    def __str__(self) -> str:
+        return '.'.join([self.base] + list(self.ext))
 
     @staticmethod
     def parse(name: str) -> 'PackageName':


### PR DESCRIPTION
This closes https://github.com/runtimeverification/kup/issues/47 as we will now be able to install a version of k with the necessary llvm libraries for building against the blockchain-plugin. Namely running `kup install k.openssl.procps` should give us the right version of K for this. This PR just enables the passing of the `.openssl.procps` argument to nix via kup.

I've re-factored the code to make it clearer what's the nixpackage name (now denoted by the `PackageName`) and what is an alias we use in kup. For most packages the alias and `package.package.base` coincide, but for example, for the kore-rpc server, we have `kore-rpc` as the kup alias (i.e. `kup shell kore-rpc`), but the nix package name is actually `'kore:exe:kore-rpc` (i.e. `nix shell github:runtimeverification/haskell-backend#'kore:exe:kore-rpc`). We must therefore take care when calling e.g. `kup shell kore-rpc.foo`, to correctly translate to `nix shell github:runtimeverification/haskell-backend#'kore:exe:kore-rpc.foo`

This should also close https://github.com/runtimeverification/kup/issues/37, as we now hide the hashes for `kup list <package> --inputs`