### PR TITLE
Reorganise parser to fix args.package error in `kup doctor`

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -860,7 +860,7 @@ def main() -> None:
 
         if args.command == 'list':
             list_package(alias, args.inputs)
-        
+
         elif args.command in {'install', 'update'}:
             install_or_update_package(
                 alias, ext, args.version, args.override, args.verbose, args.refresh, is_update=args.command == 'update'


### PR DESCRIPTION
Fixes the following error when calling `kup doctor`:

```
Traceback (most recent call last):
  File "/nix/store/akws8cid23x5dnl5nna08ypfzrnn0x2p-python3.9-kup-0.1.0/bin/.kup-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/akws8cid23x5dnl5nna08ypfzrnn0x2p-python3.9-kup-0.1.0/lib/python3.9/site-packages/kup/__main__.py", line 843, in main
    alias_with_ext = PackageName.parse(args.package)
AttributeError: 'Namespace' object has no attribute 'package'
```

This happens because we try to read the `package` argument from the parsed arguments. However, this argument is only present when calling `kup install/add/update/remove/shell`. This PR modifies the if statements in main to reflect this.