### PR TITLE
Show help when calling kup without arguments

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -844,7 +844,9 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if 'help' in args and args.help:
+    if args.command is None:
+        parser.print_help()
+    elif 'help' in args and args.help:
         with open(os.path.join(KUP_DIR, f'{args.command}-help.md'), 'r+') as help_file:
             console.print(Markdown(help_file.read(), code_theme='emacs'))
     elif args.command == 'doctor':


### PR DESCRIPTION
Show the help message when calling `kup` without any arguments. At the moment we get:

```
➜  kup git:(sam/parser-fix) kup
Traceback (most recent call last):
  File "/nix/store/n615n9aw806flyyl0k6hm3q4yb05z854-python3.9-kup-0.1.0/bin/.kup-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/n615n9aw806flyyl0k6hm3q4yb05z854-python3.9-kup-0.1.0/lib/python3.9/site-packages/kup/__main__.py", line 861, in main
    alias_with_ext = PackageName.parse(args.package)
AttributeError: 'Namespace' object has no attribute 'package'
```

with the change:

```
kup git:(sam/parser-fix) kup       
usage: kup [-h] {list,install,remove,update,shell,doctor,add} ...

The K Framework installer

positional arguments:
  {list,install,remove,update,shell,doctor,add}
    list                show the active and installed K semantics
    install             download and install the stated package
    remove              remove the given package from the user's PATH
    update              update the package to the latest version
    shell               add the selected package to the current shell (temporary)
    doctor              check if kup is installed correctly
    add                 add a private package to kup

options:
  -h, --help            show this help message and exit

additional information:
    For more detailed help for the different sub-commands, call
      kup {list,install,remove,update,shell} --help
```