### PR TITLE
More robust `kup publish`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-# 0.2.1
+# 0.2.2
 
 * `kup publish` returns exit code 1 if `cachix push/pin` commands fail
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # 0.2.1
 
+* `kup publish` returns exit code 1 if `cachix push/pin` commands fail
+
+# 0.2.1
+
 * Allow arbitrary overrides of the form `kup install ... --override ... github:...`
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "kup"
-version = "0.2.1"
+version = "0.2.2"
 description = "kup is a tool for managing installations of the K framework along with the different available semantics"
 authors = [
     "Runtime Verification, Inc. <contact@runtimeverification.com>",

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -738,17 +738,17 @@ def publish_package(cache: str, uri_or_path_with_package_name: str, keep_days: O
     else:
         rich.print('❗ [red]Could not find out path for package!')
         sys.exit(1)
-    try:
-        subprocess.call(['cachix', 'push', cache, nix_store_path])
-    except Exception:
+
+    c = subprocess.call(['cachix', 'push', cache, nix_store_path])
+    if c > 0:
         rich.print('❗ [red]Could not push binaries to cachix!')
         sys.exit(1)
-    try:
-        pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
-            ['--keep-days', str(keep_days)] if keep_days else []
-        )
-        subprocess.call(pin_args)
-    except Exception:
+
+    pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
+        ['--keep-days', str(keep_days)] if keep_days else []
+    )
+    c = subprocess.call(pin_args)
+    if c > 0:
         rich.print('❗ [red]Could not pin package! Make sure you have cachix >=1.6')
         sys.exit(1)
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -739,16 +739,17 @@ def publish_package(cache: str, uri_or_path_with_package_name: str, keep_days: O
         rich.print('❗ [red]Could not find out path for package!')
         sys.exit(1)
 
-    c = subprocess.call(['cachix', 'push', cache, nix_store_path])
-    if c > 0:
+    try:
+        subprocess.run(['cachix', 'push', cache, nix_store_path], check=True)
+    except Exception:
         rich.print('❗ [red]Could not push binaries to cachix!')
         sys.exit(1)
-
-    pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
-        ['--keep-days', str(keep_days)] if keep_days else []
-    )
-    c = subprocess.call(pin_args)
-    if c > 0:
+    try:
+        pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
+            ['--keep-days', str(keep_days)] if keep_days else []
+        )
+        subprocess.run(pin_args, check=True)
+    except Exception:
         rich.print('❗ [red]Could not pin package! Make sure you have cachix >=1.6')
         sys.exit(1)
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -738,12 +738,19 @@ def publish_package(cache: str, uri_or_path_with_package_name: str, keep_days: O
     else:
         rich.print('❗ [red]Could not find out path for package!')
         sys.exit(1)
-
-    subprocess.call(['cachix', 'push', cache, nix_store_path])
-    pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
-        ['--keep-days', str(keep_days)] if keep_days else []
-    )
-    subprocess.call(pin_args)
+    try:
+        subprocess.call(['cachix', 'push', cache, nix_store_path])
+    except Exception:
+        rich.print('❗ [red]Could not push binaries to cachix!')
+        sys.exit(1)
+    try:
+        pin_args = ['cachix', 'pin', cache, cache_key, nix_store_path] + (
+            ['--keep-days', str(keep_days)] if keep_days else []
+        )
+        subprocess.call(pin_args)
+    except Exception:
+        rich.print('❗ [red]Could not pin package! Make sure you have cachix >=1.6')
+        sys.exit(1)
 
 
 def print_help(subcommand: str, parser: ArgumentParser) -> None:


### PR DESCRIPTION
`kup publish` now returns exit code 1 if `cachix push/pin` commands fail