### PR TITLE
Nix >=2.20 breakage fixes

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -249,13 +249,15 @@ def reload_packages(load_versions: bool = True) -> None:
     if os.path.exists(f'{os.getenv("HOME")}/.nix-profile/manifest.json'):
         manifest_file = open(f'{os.getenv("HOME")}/.nix-profile/manifest.json')
         manifest = json.loads(manifest_file.read())['elements']
+        if type(manifest) is list:
+            manifest = dict(enumerate(manifest))
         manifest_file.close()
     else:
-        manifest = []
+        manifest = {}
 
     pinned_package_cache_reverse = {v: k for k, v in pinned_package_cache.items()}
     packages = {}
-    for idx, m in enumerate(manifest):
+    for idx, m in manifest.items():
         # fix potential inconsistencies between nix profiles
         # sometimes storing url/originalUrl and sometimes uri/originalUri
         if 'uri' in m:
@@ -657,7 +659,7 @@ def add_new_package(
         substituters_to_add = []
         trusted_public_keys_to_add = []
 
-        for (s, pub_key) in zip(substituters, trusted_public_keys):
+        for (s, pub_key) in zip(substituters, trusted_public_keys, strict=True):
             if s in CURRENT_SUBSTITUTERS and pub_key in CURRENT_TRUSTED_PUBLIC_KEYS:
                 pass
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -659,7 +659,7 @@ def add_new_package(
         substituters_to_add = []
         trusted_public_keys_to_add = []
 
-        for (s, pub_key) in zip(substituters, trusted_public_keys, strict=True):
+        for (s, pub_key) in zip(substituters, trusted_public_keys):
             if s in CURRENT_SUBSTITUTERS and pub_key in CURRENT_TRUSTED_PUBLIC_KEYS:
                 pass
 

--- a/src/kup/nix.py
+++ b/src/kup/nix.py
@@ -86,6 +86,15 @@ ARCH = (
     .replace('"', '')
 )
 
+# based on https://github.com/NixOS/nixpkgs/blob/d329d65edb3680f5aa7cc46b364a564bab27f8c7/nixos/modules/config/nix.nix#L114
+# to remove warnings about deprecated nix command 
+SHOW_CONFIG_COMMAND = (
+    nix_raw(['eval', '--impure', '--expr', 'if builtins.compareVersions builtins.nixVersion "2.20pre" == -1 then "show-config" else "config show"'], extra_flags=[])
+    .decode('utf8')
+    .strip()
+    .replace('"', '')
+)
+
 USER = pwd.getpwuid(os.getuid())[0]
 USER_IS_ROOT = os.geteuid() == 0
 
@@ -98,9 +107,11 @@ CURRENT_NETRC_FILE = None
 def check_substituters() -> Tuple[bool, bool]:
     global TRUSTED_USERS, CURRENT_SUBSTITUTERS, CURRENT_TRUSTED_PUBLIC_KEYS, CURRENT_NETRC_FILE
     try:
-        result = nix_raw(['show-config', '--json'], extra_flags=[])
+        cmd = SHOW_CONFIG_COMMAND.split()
+        cmd.append('--json')
+        result = nix_raw(cmd, extra_flags=[])
     except Exception:
-        rich.print("⚠️ [yellow]Could not run 'nix show-config'.")
+        rich.print(f"⚠️ [yellow]Could not run 'nix {SHOW_CONFIG_COMMAND}'.")
         return False, False
     config = json.loads(result)
     try:

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -165,7 +165,7 @@ class LocalPackage(GithubPackage):
         github_package: GithubPackage,
         package_name: PackageName,
         path: str,
-        index: int = -1,
+        index: int | str = -1,
     ):
         self.path = path
         self.index = index
@@ -237,7 +237,7 @@ class ConcretePackage(GithubPackage):
         status: str,
         commit: str,
         tag: Optional[str] = None,
-        index: int = -1,
+        index: int | str = -1,
         ssh_git: bool = False,
         access_token: Optional[str] = None,
         substituters: Optional[list[str]] = None,
@@ -283,7 +283,7 @@ class ConcretePackage(GithubPackage):
             )
 
     @staticmethod
-    def parse(url: str, package: GithubPackage, idx: int, load_versions: bool) -> 'ConcretePackage':
+    def parse(url: str, package: GithubPackage, idx: int | str, load_versions: bool) -> 'ConcretePackage':
         global tag_cache
         if package.ssh_git:
             commit = url.split('&rev=')[1]

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -165,7 +165,7 @@ class LocalPackage(GithubPackage):
         github_package: GithubPackage,
         package_name: PackageName,
         path: str,
-        index: int | str = -1,
+        index: Union[int, str] = -1,
     ):
         self.path = path
         self.index = index
@@ -237,7 +237,7 @@ class ConcretePackage(GithubPackage):
         status: str,
         commit: str,
         tag: Optional[str] = None,
-        index: int | str = -1,
+        index: Union[int, str] = -1,
         ssh_git: bool = False,
         access_token: Optional[str] = None,
         substituters: Optional[list[str]] = None,
@@ -283,7 +283,7 @@ class ConcretePackage(GithubPackage):
             )
 
     @staticmethod
-    def parse(url: str, package: GithubPackage, idx: int | str, load_versions: bool) -> 'ConcretePackage':
+    def parse(url: str, package: GithubPackage, idx: Union[int, str], load_versions: bool) -> 'ConcretePackage':
         global tag_cache
         if package.ssh_git:
             commit = url.split('&rev=')[1]


### PR DESCRIPTION
Fixes  #97


There are some recent changes in nix, affecting kup, namely:

* As of nix version 2.20, the command `nix show-config` shows a deprecation warning and has been replaced by `nix config show`
* The nix profile manifest format has changed and instead of using indices to refer to packages, it now uses the package name itself. This is the reason of recent breakage reported in #97