### PR TITLE
Add `kup gc` command

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -900,7 +900,7 @@ def main() -> None:
     publish.add_argument('uri', type=str)
     publish.add_argument('--keep-days', type=int, help='keep package cached for N days')
 
-    subparser.add_parser('gc', help='Call nix garbage collector to remove previously unistalled packages', add_help=False)
+    subparser.add_parser('gc', help='Call Nix garbage collector to remove previously uninstalled packages', add_help=False)
 
     args = parser.parse_args()
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -900,6 +900,8 @@ def main() -> None:
     publish.add_argument('uri', type=str)
     publish.add_argument('--keep-days', type=int, help='keep package cached for N days')
 
+    subparser.add_parser('gc', help='Call nix garbage collector to remove previously unistalled packages', add_help=False)
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -919,6 +921,14 @@ def main() -> None:
             ask_install_substituters('k-framework', [K_FRAMEWORK_CACHE], [K_FRAMEWORK_PUBLIC_KEY])
     elif args.command == 'publish':
         publish_package(args.cache, args.uri, args.keep_days)
+    elif args.command == 'gc':
+        try:
+            subprocess.check_output(
+                ['nix-collect-garbage', '-d'],
+            )
+        except subprocess.CalledProcessError as exc: 
+            print(exc)
+            sys.exit(exc.returncode)
     else:
         package_name = PackageName.parse(args.package)
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -900,7 +900,9 @@ def main() -> None:
     publish.add_argument('uri', type=str)
     publish.add_argument('--keep-days', type=int, help='keep package cached for N days')
 
-    subparser.add_parser('gc', help='Call Nix garbage collector to remove previously uninstalled packages', add_help=False)
+    subparser.add_parser(
+        'gc', help='Call Nix garbage collector to remove previously uninstalled packages', add_help=False
+    )
 
     args = parser.parse_args()
 
@@ -926,7 +928,7 @@ def main() -> None:
             subprocess.check_output(
                 ['nix-collect-garbage', '-d'],
             )
-        except subprocess.CalledProcessError as exc: 
+        except subprocess.CalledProcessError as exc:
             print(exc)
             sys.exit(exc.returncode)
     else:


### PR DESCRIPTION
This fixes #95 by adding the `kup gc` command, which is just an alias for `nix-collect-garbage -d`. Not sure about the name, neither `gc` nor `purge` seem right... perhaps `kup garbage-collect`... might be a bit long?