### PR TITLE
Refresh on nix copy

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -484,6 +484,7 @@ def install_package(
         nix(
             ['copy', '--from', K_FRAMEWORK_BINARY_CACHE, pinned_package_cache[package.uri]],
             verbose=VERBOSE,
+            refresh=True,
         )
         if package_name.base in installed_packages:
             nix(['profile', 'remove', str(package.index)], is_install=False)
@@ -1000,6 +1001,7 @@ def main() -> None:
                 nix(
                     ['copy', '--from', K_FRAMEWORK_BINARY_CACHE, pinned_package_cache[package.uri]],
                     verbose=VERBOSE,
+                    refresh=True,
                 )
                 nix_detach(
                     ['shell', pinned_package_cache[package.uri]],


### PR DESCRIPTION
Recent issues with dependencies missing from the binary cache highlighted that we should call nix copy with `--refresh` otherwise nix will assume the paths are still missing from the cache.