### PR TITLE
Refresh when installing new package

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -502,6 +502,7 @@ def install_package(
             extra_substituters=package.substituters,
             extra_public_keys=package.public_keys,
             verbose=VERBOSE,
+            refresh=True,
         )
         if package_name.base in installed_packages:
             nix(['profile', 'remove', str(package.index)], is_install=False)


### PR DESCRIPTION
Yet another place we should call nix with `--refresh` to avoid stale versions