### PR TITLE
Update kup package list

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -65,8 +65,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol')),
     GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-exec')),
     GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-rpc')),
-    GithubPackage('runtimeverification', 'hs-backend-booster', PackageName('kore-rpc-booster'), 'main'),
-    GithubPackage('runtimeverification', 'pyk', PackageName('pyk')),
+    GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-rpc-booster')),
 ]
 
 

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -63,9 +63,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'plutus-core-semantics', PackageName('kplutus')),
     GithubPackage('runtimeverification', 'mir-semantics', PackageName('kmir')),
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol')),
-    GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-exec')),
-    GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-rpc')),
-    GithubPackage('runtimeverification', 'haskell-backend', PackageName('kore-rpc-booster')),
+    GithubPackage('runtimeverification', 'kasmer-multiversx', PackageName('kmxwasm')),
 ]
 
 


### PR DESCRIPTION
* Fixes #114 by removing pyk from the package list, as the pyk repository has been merged into K (not sure if we want to have pyk as a target. If so, we will need to modify the k repo flake to expose pyk properly and then re-add it here).
* Removes all standalone haskell binaries as they are included in k and should be canonically used from that derivation
* Add [kasmer](https://github.com/runtimeverification/kasmer-multiversx)