### PR TITLE
Add `K_FRAMEWORK_BINARY_CACHE` to `print_substituters_warning`

### DIFF
--- a/src/kup/nix.py
+++ b/src/kup/nix.py
@@ -295,9 +295,9 @@ def print_substituters_warning() -> None:
     add_user_to_trusted = ' '.join(new_trusted_users)
     add_user_to_trusted_nix = ' '.join([f'"{s}"' for s in new_trusted_users])
     rich.print(
-        f'\n⚠️ [yellow] The k-framework binary cache [green]{K_FRAMEWORK_CACHE}[/] is not configured in your nix installation and\n'
-        'the current user does not have sufficient permissions to add and use it.\n'
-        '[blue]kup[/] relies on this cache to provide faster installation using pre-built binaries.[/]\n\n'
+        f'\n⚠️ [yellow] The k-framework binary caches [green]{K_FRAMEWORK_CACHE}[/] and [green]{K_FRAMEWORK_BINARY_CACHE}[/] are\n'
+        'not configured in your nix installation and the current user does not have sufficient permissions to add and use them.\n'
+        '[blue]kup[/] relies on these caches to provide faster installation using pre-built binaries.[/]\n\n'
         'You can still install kup packages from source, however, to avoid building the packages on your local machine, consider:\n'
     )
     if NIXOS_VERSION is None:


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/kup/issues/117.

Makes it clear that both `K_FRAMEWORK_CACHE` and `K_FRAMEWORK_BINARY_CACHE` need to be configured.

The substituter error message now looks similar to:
![image](https://github.com/runtimeverification/kup/assets/5212453/ae8330d7-f926-461a-b9b8-69e3eb2d89be)
