### PR TITLE
Fix tagged commits listing for non-master branches

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -59,7 +59,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'kup', PackageName('kup')),
     GithubPackage('runtimeverification', 'k', PackageName('k')),
     GithubPackage('runtimeverification', 'avm-semantics', PackageName('kavm')),
-    GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm'), branch="release"),
+    GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm'), branch='release'),
     GithubPackage('runtimeverification', 'plutus-core-semantics', PackageName('kplutus')),
     GithubPackage('runtimeverification', 'mir-semantics', PackageName('kmir')),
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol')),

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -59,7 +59,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'kup', PackageName('kup')),
     GithubPackage('runtimeverification', 'k', PackageName('k')),
     GithubPackage('runtimeverification', 'avm-semantics', PackageName('kavm')),
-    GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm')),
+    GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm'), branch="release"),
     GithubPackage('runtimeverification', 'plutus-core-semantics', PackageName('kplutus')),
     GithubPackage('runtimeverification', 'mir-semantics', PackageName('kmir')),
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol')),
@@ -339,8 +339,9 @@ def list_package(
             if not tags.ok:
                 rich.print('❗ Listing versions is unsupported for private packages accessed over SSH.')
                 return
+            branch = f'?sha={listed_package.branch}' if listed_package.branch else ''
             commits = requests.get(
-                f'https://api.github.com/repos/{listed_package.org}/{listed_package.repo}/commits', headers=auth
+                f'https://api.github.com/repos/{listed_package.org}/{listed_package.repo}/commits{branch}', headers=auth
             )
             tagged_releases = {t['commit']['sha']: t for t in tags.json()}
             all_releases = [


### PR DESCRIPTION
This PR fixes #122 by:

* Pointing the `kevm` package to the `release` branch, which is where we are now tagging releases
* Fix Github API call which retrieves the latest commits, to fetch commits from a custom branch, e.g. `release`, when supplied.

Before:

```
kup list kevm 
┌─────────────────────┬─────────┬────────────────────────────────────────────────────┬────────┐
│ Version (installed) │ Commit  │ Message                                            │ Cached │
├─────────────────────┼─────────┼────────────────────────────────────────────────────┼────────┤
│                     │ 933d660 │ Update dependency: deps/k_release (#2577) *...     │        │
│                     │ 2330063 │ Update dependency: kevm-...                        │        │
│                     │ a29f783 │ Hotfix/push release with pat (#2574) * Force...    │        │
│                     │ 25de575 │ Update dependency: deps/k_release (#2572) *...     │        │
│                     │ 0b75078 │ Enable Outside Collaborators to run test suite...  │        │
│ v1.0.677            │ ef64079 │ Update dependency: deps/k_release (#2570) *...     │        │
│ v1.0.676            │ 25be766 │ Adding support for the `--assume-defined` flag...  │        │
│ v1.0.675            │ 4c5b500 │ Update dependency: deps/k_release (#2569) *...     │        │
│ v1.0.674            │ a215e71 │ Update dependency: deps/k_release (#2567) *...     │        │
│ v1.0.673            │ 16dac73 │ Partial evaluation of EVM optimization lemmas...   │        │
│ v1.0.672            │ 6e916f3 │ Update dependency: deps/k_release (#2564) *...     │        │
│ v1.0.671            │ ffea690 │ Add `--maintenance-rate` option (#2563) * Add...   │        │
│ v1.0.670            │ 5535f00 │ Update dependency: deps/k_release (#2562) *...     │        │
│ v1.0.669            │ 7644b36 │ Update dependency: kevm-...                        │        │
│ v1.0.668            │ e6638be │ Update dependency: deps/k_release (#2558) *...     │        │
│ v1.0.667            │ f11a268 │ proxy: install-build-deps: Automate...             │        │
│ v1.0.666            │ c7c8fe1 │ Update dependency: deps/k_release (#2554) *...     │        │
│ v1.0.665            │ ee44274 │ Update dependency: kevm-...                        │        │
│ v1.0.664            │ ce37791 │ Update dependency: deps/k_release (#2548) *...     │        │
│ v1.0.663            │ 14c9d29 │ EIP-4788: Beacon Roots contract (#2546) *...       │        │
│ v1.0.662            │ 394c1ec │ Increase the number of tests run with the...       │        │
│ v1.0.661            │ d7f2081 │ Load claims using `ClaimLoader` (#2532) *...       │        │
│ v1.0.660            │ c325c55 │ Execute multiple blocks in conformance tests...    │        │
│ v1.0.659            │ 2c10f04 │ Add status bar support (#2543) * Add status bar... │        │
│ v1.0.658            │ d1b17a1 │ Update dependency: deps/k_release (#2544) *...     │        │
│ v1.0.657            │ 57a0267 │ Update dependency: kevm-...                        │        │
│ v1.0.656            │ f33b28c │ Update dependency: deps/k_release (#2542) *...     │        │
│ v1.0.655            │ 92153d0 │ Update dependency: deps/k_release (#2539) *...     │        │
│ v1.0.654            │ f227fe5 │ Update dependency: kevm-...                        │        │
│ v1.0.653            │ ba8be1a │ Update dependency: deps/k_release (#2538) *...     │        │
└─────────────────────┴─────────┴────────────────────────────────────────────────────┴────────┘
```

After:

```
┌─────────────────────┬─────────┬───────────────────────────────────────────────────┬────────┐
│ Version (installed) │ Commit  │ Message                                           │ Cached │
├─────────────────────┼─────────┼───────────────────────────────────────────────────┼────────┤
│ v1.0.682            │ cb91fb4 │ Set Version: 1.0.682                              │        │
│                     │ 90806fd │ Merge remote-tracking branch 'origin/master'...   │        │
│                     │ 933d660 │ Update dependency: deps/k_release (#2577) *...    │        │
│ v1.0.681            │ b4afee5 │ Set Version: 1.0.681                              │        │
│                     │ b4bcc9d │ Merge remote-tracking branch 'origin/master'...   │        │
│                     │ 2330063 │ Update dependency: kevm-...                       │        │
│ v1.0.680            │ fe30b7b │ Set Version: 1.0.680                              │        │
│                     │ 74551b9 │ Merge remote-tracking branch 'origin/master'...   │        │
│                     │ a29f783 │ Hotfix/push release with pat (#2574) * Force...   │        │
│                     │ 9fe0c97 │ Set Version: 1.0.679                              │        │
│                     │ 1082310 │ Set Version: 1.0.678                              │        │
│                     │ b431f24 │ Merge remote-tracking branch 'origin/master'...   │        │
│                     │ 25de575 │ Update dependency: deps/k_release (#2572) *...    │        │
│                     │ 937f8ea │ Set Version: 1.0.678                              │        │
│                     │ 0b75078 │ Enable Outside Collaborators to run test suite... │        │
│ v1.0.677            │ ef64079 │ Update dependency: deps/k_release (#2570) *...    │        │
│ v1.0.676            │ 25be766 │ Adding support for the `--assume-defined` flag... │        │
│ v1.0.675            │ 4c5b500 │ Update dependency: deps/k_release (#2569) *...    │        │
│ v1.0.674            │ a215e71 │ Update dependency: deps/k_release (#2567) *...    │        │
│ v1.0.673            │ 16dac73 │ Partial evaluation of EVM optimization lemmas...  │        │
│ v1.0.672            │ 6e916f3 │ Update dependency: deps/k_release (#2564) *...    │        │
│ v1.0.671            │ ffea690 │ Add `--maintenance-rate` option (#2563) * Add...  │        │
│ v1.0.670            │ 5535f00 │ Update dependency: deps/k_release (#2562) *...    │        │
│ v1.0.669            │ 7644b36 │ Update dependency: kevm-...                       │        │
│ v1.0.668            │ e6638be │ Update dependency: deps/k_release (#2558) *...    │        │
│ v1.0.667            │ f11a268 │ proxy: install-build-deps: Automate...            │        │
│ v1.0.666            │ c7c8fe1 │ Update dependency: deps/k_release (#2554) *...    │        │
│ v1.0.665            │ ee44274 │ Update dependency: kevm-...                       │        │
│ v1.0.664            │ ce37791 │ Update dependency: deps/k_release (#2548) *...    │        │
│ v1.0.663            │ 14c9d29 │ EIP-4788: Beacon Roots contract (#2546) *...      │        │
└─────────────────────┴─────────┴───────────────────────────────────────────────────┴────────┘
```