### PR TITLE
Omit the branch name when matching packages in manifest.json

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -276,7 +276,8 @@ def reload_packages(load_versions: bool = True) -> None:
             available_package = lookup_available_package(m['attrPath'])
             if available_package is not None:
                 repo_path, _ = available_package.repo_path_with_access()
-                if 'url' in m and m['url'].startswith(repo_path):
+                base_repo_path = available_package.base_repo_path
+                if 'url' in m and m['url'].startswith(base_repo_path):
                     packages[available_package.package_name.base] = ConcretePackage.parse(
                         m['url'], available_package, idx, load_versions
                     )

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -275,7 +275,6 @@ def reload_packages(load_versions: bool = True) -> None:
         if 'attrPath' in m and m['attrPath']:
             available_package = lookup_available_package(m['attrPath'])
             if available_package is not None:
-                repo_path, _ = available_package.repo_path_with_access()
                 base_repo_path = available_package.base_repo_path
                 if 'url' in m and m['url'].startswith(base_repo_path):
                     packages[available_package.package_name.base] = ConcretePackage.parse(

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -115,6 +115,10 @@ class GithubPackage:
         path, _ = self.repo_path_with_access()
         return f'{path}#{self.package_name}'
 
+    @property
+    def base_repo_path(self) -> str:
+        return f'github:{self.org}/{self.repo}'
+
     def concrete(
         self, override_branch_tag_commit_or_path: Optional[str] = None, ext: Optional[Iterable[str]] = None
     ) -> Union['ConcretePackage', 'LocalPackage']:


### PR DESCRIPTION
Closes: #130 
The `kontrol` package is defined in `available_packages` with a specific branch:
```py
    GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol'), branch='release'),
```

From the `manifest.json`, we can see that the kontrol entry looks like this:
```json
{
  "kontrol": {
    "active": true,
    "attrPath": "packages.x86_64-linux.kontrol",
    "originalUrl": "github:runtimeverification/kontrol/acca16ffd6f4e693b7bda2dd8ca99eb335057dbe?narHash=...",
    "url": "github:runtimeverification/kontrol/acca16ffd6f4e693b7bda2dd8ca99eb335057dbe?narHash=..."
  },
}
```

When kup tries to match the installed packages with the available packages, it compares the `repo_path` (which includes the branch) with the url from the manifest (which does not include the branch). This mismatch causes kup to incorrectly conclude that kontrol is not installed.

![image](https://github.com/user-attachments/assets/69fa238c-6054-4d22-b99a-ca0644aa6c0f)
