### PR TITLE
Fix branch for installed packages

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -516,7 +516,13 @@ def install_package(
         )
 
     verb = 'updated' if package_name.base in installed_packages else 'installed'
-    display_version = f' ({package_version})' if package_version else ' (master)'
+    if package_version is not None:
+        display_version = package_version
+    elif package.branch is not None:
+        display_version = package.branch
+    else:
+        display_version = 'master'
+    display_version = f' ({display_version})'
     rich.print(
         f" ✅ Successfully {verb} '[green]{package_name.base}[/]' version [blue]{package.uri}{display_version}[/]."
     )

--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -516,13 +516,15 @@ def install_package(
         )
 
     verb = 'updated' if package_name.base in installed_packages else 'installed'
+
     if package_version is not None:
         display_version = package_version
     elif package.branch is not None:
         display_version = package.branch
     else:
-        display_version = 'master'
-    display_version = f' ({display_version})'
+        display_version = None
+    display_version = f' ({display_version})' if display_version is not None else ''
+
     rich.print(
         f" ✅ Successfully {verb} '[green]{package_name.base}[/]' version [blue]{package.uri}{display_version}[/]."
     )

--- a/src/kup/package.py
+++ b/src/kup/package.py
@@ -246,12 +246,13 @@ class ConcretePackage(GithubPackage):
         access_token: Optional[str] = None,
         substituters: Optional[list[str]] = None,
         public_keys: Optional[list[str]] = None,
+        update_branch: Optional[str] = None,
     ):
         self.commit = commit
         self.status = status
         self.index = index
         self.tag = tag
-        super().__init__(org, repo, package, None, ssh_git, access_token, substituters, public_keys)
+        super().__init__(org, repo, package, update_branch, ssh_git, access_token, substituters, public_keys)
 
     @property
     def concrete_repo_path_with_access(self) -> Tuple[str, List[str]]:
@@ -321,6 +322,7 @@ class ConcretePackage(GithubPackage):
             tag,
             idx,
             package.ssh_git,
+            update_branch=package.branch,
         )
 
 


### PR DESCRIPTION
`kup` loads a list of packages that it manages augmented with information from respectively installed packages . Previously, when a package that is managed by `kup` is also installed on the users system, the release branch information was lost.

This caused `kup install` to always install the latest version of the master branch, when the package was already installed. Note: `kup update` is an alias for `kup install`. When the release branch of a given package is not the master branch, e.g. for kontrol, then a `kup install` operation always built the package from source instead of fetching from cache.

The `kup list` and `kup list [package]` operations were also broken due to this. In case of `kup list`, a package was marked as not up-to-date when the respective non-release master branch was installed due to the previously described bug. `kup list [package]` on the other hand was broken as long as the respective package was installed, as the release branch information got lost, when the package had a release branch different from the master branch.

On another note, the branch that is printed when installing a package without specifically stating a version to install was always `master`, despite the installed release branch potentially being different.

This pull request fixes the information loss and therefore fixes several bugs/inconsistencies observed with `kup install`, `kup list`, and `kup list [package]`. Also, the branch that is printed now always properly reflects the actual branch that is installed.