### PR TITLE
Change kmir branch from `master` to `release`

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -64,7 +64,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'avm-semantics', PackageName('kavm')),
     GithubPackage('runtimeverification', 'evm-semantics', PackageName('kevm'), branch='release'),
     GithubPackage('runtimeverification', 'plutus-core-semantics', PackageName('kplutus')),
-    GithubPackage('runtimeverification', 'mir-semantics', PackageName('kmir')),
+    GithubPackage('runtimeverification', 'mir-semantics', PackageName('kmir'), branch='release'),
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol'), branch='release'),
     GithubPackage('runtimeverification', 'kasmer-multiversx', PackageName('kmxwasm')),
     GithubPackage('runtimeverification', 'komet', PackageName('komet')),


### PR DESCRIPTION
mir-semantics has changed their release branch from `master` to a dedicated `release` branch. With a new working nix derivation, we have to update the configured branch in `kup` to profit from the builds pushed to the nix cache.

This PR changed the branch of `kmir` from `master` to `release`.