### PR TITLE
Add `skribe`

### DIFF
--- a/src/kup/__main__.py
+++ b/src/kup/__main__.py
@@ -68,6 +68,7 @@ available_packages: list[GithubPackage] = [
     GithubPackage('runtimeverification', 'kontrol', PackageName('kontrol'), branch='release'),
     GithubPackage('runtimeverification', 'kasmer-multiversx', PackageName('kmxwasm')),
     GithubPackage('runtimeverification', 'komet', PackageName('komet')),
+    GithubPackage('runtimeverification', 'skribe', PackageName('skribe')),
 ]
 
 


### PR DESCRIPTION
Currently, the Nix setup in the [skribe](github.com/runtimeverification/skribe) project exposes only `skribe-simulation`. Once the skribe PR that exposes the main `skribe` binary is merged, kup will install both `skribe` and `skribe-simulation`.
*  runtimeverification/skribe#33