### PR TITLE
WIP: Machine-readable output

### DIFF
--- a/src/kup/output.py
+++ b/src/kup/output.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+import json
+import rich
+
+if TYPE_CHECKING:
+    from typing import Any
+
+_JSON_OUTPUT = False
+
+def set_json_output(enabled: bool) -> None:
+    global _JSON_OUTPUT
+    _JSON_OUTPUT = enabled
+
+def is_json_output() -> bool:
+    return _JSON_OUTPUT
+
+def print_human(rich_data: Any) -> None:
+    if not _JSON_OUTPUT:
+        rich.print(rich_data)
+
+def print_machine(json_data: dict[str, Any]) -> None:
+    if _JSON_OUTPUT:
+        print(json.dumps(json_data, indent=2), end=',\n')


### PR DESCRIPTION
This PR adds machine-readable output to kup. When `kup` is called with `--json` flag, the output will be in [JSON Lines](https://jsonlines.org/) format.
This allows external tools (first and foremost Simbolik) to interact with kup more easily, because we don't have to parse human readable text messages.