### PR TITLE
Bump python 3.9 -> 3.11

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -30,7 +30,7 @@ jobs:
           skipPush: true
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9' 
+          python-version: '3.11'
       - name: 'Install Poetry'
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           p2n = poetry2nix.lib.mkPoetry2Nix { pkgs = final; };
         in {
           kup = p2n.mkPoetryApplication {
-            python = prev.python39;
+            python = prev.python311;
             projectDir = ./.;
             # We remove `"dev"` from `checkGroups`, so that poetry2nix does not try to resolve dev dependencies.
             checkGroups = [];

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,7 +32,6 @@ files = [
 
 [package.dependencies]
 pyflakes = ">=1.1.0"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "black"
@@ -70,8 +69,6 @@ click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -308,7 +305,6 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -505,19 +501,6 @@ lint = ["flake8 (==3.9.2)"]
 tests = ["pytest"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-markers = "python_full_version < \"3.11.0a7\""
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "types-requests"
 version = "2.28.11.2"
 description = "Typing stubs for requests"
@@ -575,5 +558,5 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "bc2c286fd3c8a955e361f1dc8d0b0c780c9d60fdae10fed7ccd6bbd853aa6205"
+python-versions = "^3.11"
+content-hash = "27142d7a22ac036d66293b5368195096ff907a34e77b1e714f14001b22c676a0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 kup = "kup.__main__:main"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.11"
 terminaltables = "^3.1.10"
 requests = "^2.28.1"
 types-requests = "^2.28.11"


### PR DESCRIPTION
Bumping the Python version from 3.9 to 3.11, as the Poetry installation fails in CI with Python 3.9 (see https://github.com/runtimeverification/kup/actions/runs/21142954948/job/60987062946).
Tested in #144.